### PR TITLE
Hashsum

### DIFF
--- a/updater/download.py
+++ b/updater/download.py
@@ -26,7 +26,7 @@ class DataSource(ABC):
         series_df = self.download()
 
         hashsum = sha256(series_df.to_csv().encode()).hexdigest()
-        print("  -", hashsum)
+        #print("  -", hashsum)
 
         data = {
             "hashsum": hashsum,

--- a/updater/download.py
+++ b/updater/download.py
@@ -26,7 +26,7 @@ class DataSource(ABC):
         series_df = self.download()
 
         hashsum = sha256(series_df.to_csv().encode()).hexdigest()
-        #print("  -", hashsum)
+        # print("  -", hashsum)
 
         data = {
             "hashsum": hashsum,

--- a/updater/download.py
+++ b/updater/download.py
@@ -29,7 +29,7 @@ class DataSource(ABC):
         print("  -", hashsum)       
         
         data = {
-            "sha256": hashsum,
+            "hashsum": hashsum,
             "series_df": series_df,
             "downloaded_at": datetime.datetime.now(),
         }

--- a/updater/download.py
+++ b/updater/download.py
@@ -24,10 +24,10 @@ class DataSource(ABC):
     def fetch(self):
         print(self.title)
         series_df = self.download()
-        
+
         hashsum = sha256(series_df.to_csv().encode()).hexdigest()
-        print("  -", hashsum)       
-        
+        print("  -", hashsum)
+
         data = {
             "hashsum": hashsum,
             "series_df": series_df,

--- a/updater/download.py
+++ b/updater/download.py
@@ -10,6 +10,7 @@ import xml.etree.ElementTree as ET
 import pandas as pd
 import pickle
 import datetime
+from hashlib import sha256
 
 
 class DataSource(ABC):
@@ -22,9 +23,13 @@ class DataSource(ABC):
 
     def fetch(self):
         print(self.title)
-
         series_df = self.download()
+        
+        hashsum = sha256(series_df.to_csv().encode()).hexdigest()
+        print("  -", hashsum)       
+        
         data = {
+            "sha256": hashsum,
             "series_df": series_df,
             "downloaded_at": datetime.datetime.now(),
         }

--- a/updater/run_models.py
+++ b/updater/run_models.py
@@ -129,6 +129,7 @@ def cross_val_score(model, y, cv, scorer, fit_params={}):
 
     return np.mean(errors)
 
+
 # Short-circuit forecasting if hashsums match
 def check_cache(download_pickle, cache_pickle):
 
@@ -138,21 +139,21 @@ def check_cache(download_pickle, cache_pickle):
     f.close()
 
     download_hashsum = downloaded_dict["hashsum"]
-    
+
     # Debug: modify the download_hashsum (as if data had changed)
     # to force re-calculation of all forecasts.
-    #download_hashsum = "X" + download_hashsum[1:]
+    # download_hashsum = "X" + download_hashsum[1:]
 
-    #print("  - download:", download_hashsum)
+    # print("  - download:", download_hashsum)
 
     if os.path.isfile(cache_pickle):
         f = open(cache_pickle, "rb")
         cache_dict = pickle.load(f)
         f.close()
-   
+
         if "hashsum" in cache_dict["downloaded_dict"]:
             cache_hashsum = cache_dict["downloaded_dict"]["hashsum"]
-            if cache_hashsum == download_hashsum:    
+            if cache_hashsum == download_hashsum:
                 return downloaded_dict, cache_dict
 
     return downloaded_dict, None
@@ -169,7 +170,7 @@ def run_models(sources_path, download_dir_path, forecast_dir_path):
 
             downloaded_dict, cache_dict = check_cache(
                 f"{download_dir_path}/{data_source_dict['title']}.pkl",
-                f"{forecast_dir_path}/{data_source_dict['title']}.pkl"
+                f"{forecast_dir_path}/{data_source_dict['title']}.pkl",
             )
 
             # Read local pickle that we created earlier


### PR DESCRIPTION
This patch identifies datasets that have not changed since forecasts were last computed. For datasets identified in this way, the updater simply re-uses the previously computed forecasts instead of recomputing from scratch. This patch means that the nightly update only has to cope with datasets that have changed in the past day. This reduced compute load might be helpful once the number of included datasets scales up significantly.

In `hashsum` branch, re-using forecasts from the pickle completes in negligible time (<1s for whole script):
```
Australian GDP Growth
  - Re-using   : Naive
  - Re-using   : Theta
```

If the pickle is not present or the hashsums don't match, all forecasts are re-computed:
```
Australian GDP Growth
  - Calculating: Naive
  - Calculating: Theta
```

When adding a new modelling method, efficiently re-uses the cached forecasts that are available:
```
Australian GDP Growth
  - Re-using   : Naive
  - Calculating: Damped (ZZN, Damped)
  - Re-using   : Theta
```

To force re-calculation of all forecasts, simply delete the pickle/s in `data/forecasts/*.pkl`.

