### PR TITLE
Added watermark to all figures and USYD logo to about page

### DIFF
--- a/dash/pages.py
+++ b/dash/pages.py
@@ -20,8 +20,9 @@ from util import (
     location_ignore_null,
     parse_state,
     apply_default_value,
-    watermark_information
+    watermark_information,
 )
+
 
 def dash_kwarg(inputs):
     def accept_func(func):
@@ -152,9 +153,11 @@ def select_best_model(data_dict):
     return model_name
 
 
-def get_thumbnail_figure(data_dict, lg = 12):
-    watermark_config = watermark_information() #Grab the watermark text and fontsize information
-    
+def get_thumbnail_figure(data_dict, lg=12):
+    watermark_config = (
+        watermark_information()
+    )  # Grab the watermark text and fontsize information
+
     model_name = select_best_model(data_dict)
     series_df = data_dict["downloaded_dict"]["series_df"].iloc[-16:, :]
     forecast_df = data_dict["all_forecasts"][model_name]["forecast_df"]
@@ -182,17 +185,21 @@ def get_thumbnail_figure(data_dict, lg = 12):
         yaxis=dict(fixedrange=True, gridcolor="rgb(255,255,255)"),
         shapes=shapes,
         margin={"l": 0, "r": 0},
-        annotations=[dict(
-            name="watermark",
-            text=watermark_config['text'],
-            opacity=0.2,
-            font=dict(color="black", size=watermark_config['font_size'][lg]),
-            xref="paper",
-            yref="paper",
-            x=0.025, #x axis location relative to bottom left hand corner between (0,1)
-            y=0.025, #y axis location relative to bottom left hand corner between (0,1)
-            showarrow=False,
-        )],
+        annotations=[
+            dict(
+                name="watermark",
+                text=watermark_config["text"],
+                opacity=0.2,
+                font=dict(
+                    color="black", size=watermark_config["font_size"][lg]
+                ),
+                xref="paper",
+                yref="paper",
+                x=0.025,  # x axis location relative to bottom left hand corner between (0,1)
+                y=0.025,  # y axis location relative to bottom left hand corner between (0,1)
+                showarrow=False,
+            )
+        ],
     )
 
     return dict(data=data, layout=layout)
@@ -200,7 +207,7 @@ def get_thumbnail_figure(data_dict, lg = 12):
 
 def get_series_figure(data_dict, model_name):
     watermark_config = watermark_information()
-    
+
     series_df = data_dict["downloaded_dict"]["series_df"]
     forecast_df = data_dict["all_forecasts"][model_name]["forecast_df"]
 
@@ -269,17 +276,21 @@ def get_series_figure(data_dict, model_name):
             autorange=True,
             gridcolor="rgb(255,255,255)",
         ),
-        annotations=[dict(
-            name="watermark",
-            text=watermark_config['text'],
-            opacity=0.2,
-            font=dict(color="black", size=watermark_config['font_size'][12]),
-            xref="paper",
-            yref="paper",
-            x=0.025, #x axis location relative to bottom left hand corner between (0,1)
-            y=0.025, #y axis location relative to bottom left hand corner between (0,1)
-            showarrow=False,
-        )],
+        annotations=[
+            dict(
+                name="watermark",
+                text=watermark_config["text"],
+                opacity=0.2,
+                font=dict(
+                    color="black", size=watermark_config["font_size"][12]
+                ),
+                xref="paper",
+                yref="paper",
+                x=0.025,  # x axis location relative to bottom left hand corner between (0,1)
+                y=0.025,  # y axis location relative to bottom left hand corner between (0,1)
+                showarrow=False,
+            )
+        ],
         shapes=shapes,
     )
 
@@ -313,8 +324,7 @@ def component_figs_2col(row_title, series_titles):
                         [
                             dcc.Graph(
                                 figure=get_thumbnail_figure(
-                                    get_forecast_data(series_title), 
-                                    lg = 6
+                                    get_forecast_data(series_title), lg=6
                                 ),
                                 config={"displayModeBar": False},
                             )
@@ -350,8 +360,7 @@ def component_figs_3col(row_title, series_titles):
                         [
                             dcc.Graph(
                                 figure=get_thumbnail_figure(
-                                    get_forecast_data(series_title),
-                                    lg = 4
+                                    get_forecast_data(series_title), lg=4
                                 ),
                                 config={"displayModeBar": False},
                             )
@@ -504,7 +513,7 @@ class Index(BootstrapApp):
                                                             get_forecast_data(
                                                                 feature_series_title
                                                             ),
-                                                            lg = 8,
+                                                            lg=8,
                                                         ),
                                                         config={
                                                             "displayModeBar": False
@@ -545,8 +554,8 @@ class Index(BootstrapApp):
                                                         figure=get_thumbnail_figure(
                                                             get_forecast_data(
                                                                 "US Unemployment"
-                                                            ), 
-                                                            lg = 8,
+                                                            ),
+                                                            lg=8,
                                                         ),
                                                         config={
                                                             "displayModeBar": False

--- a/dash/util.py
+++ b/dash/util.py
@@ -50,9 +50,22 @@ def apply_default_value(params):
 
     return wrapper
 
-def watermark_information(): 
-    current_date = datetime.today().strftime('%Y/%m/%d') #Get the current date YYYY-MM-DD format for watermarking figures
-    watermark_text = "https://business-forecast-lab.com - {}".format(current_date)
-    watermark_font_size_dict = {12:20, 8:15, 6:12, 4:10} #Size is based upon the number of columns in the row. based upon the lg argument in dcc.Col
-    watermark_dict = {'text':watermark_text,'font_size':watermark_font_size_dict}
+
+def watermark_information():
+    current_date = datetime.today().strftime(
+        "%Y/%m/%d"
+    )  # Get the current date YYYY-MM-DD format for watermarking figures
+    watermark_text = "https://business-forecast-lab.com - {}".format(
+        current_date
+    )
+    watermark_font_size_dict = {
+        12: 20,
+        8: 15,
+        6: 12,
+        4: 10,
+    }  # Size is based upon the number of columns in the row. based upon the lg argument in dcc.Col
+    watermark_dict = {
+        "text": watermark_text,
+        "font_size": watermark_font_size_dict,
+    }
     return watermark_dict


### PR DESCRIPTION
The watermark font size is scaled based upon the number of figures in each row of the website. This is based upon the lg argument of the dcc.Col. For now the watermark uses a static web address.

The USYD logo on the about page links to the USYD business school website.